### PR TITLE
fix: Resolve CI failures

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -8,3 +8,9 @@
 ^default\.sh$
 ^nix-shell-root$
 ^test_dashboard\.R$
+^_targets\.R$
+^default-ci\.nix$
+^README\.qmd$
+^result$
+^issue_number\.txt$
+^plans$

--- a/R/dev/issues/fix_issue_1.R
+++ b/R/dev/issues/fix_issue_1.R
@@ -1,0 +1,12 @@
+# Fix Script for Issue #1: CI Failures
+# Created: 2026-01-24
+# Updated: 2026-01-24 17:27:17
+
+# FIXES APPLIED:
+# 1. Fixed Rd cross-reference warning in R/mills_ratio.R
+#    - Escaped square brackets in roxygen2 comment
+# 2. Added missing entries to .Rbuildignore
+#    - _targets.R, default-ci.nix, README.qmd, result, issue_number.txt, plans
+
+# Run devtools::document() to regenerate documentation
+# Run devtools::check() to verify fixes

--- a/R/mills_ratio.R
+++ b/R/mills_ratio.R
@@ -4,7 +4,7 @@
 #' Functions to compute Mills ratios for different probability distributions.
 #' The Mills ratio m(x) is defined as the ratio of the complementary cumulative
 #' distribution function (CCDF) to the probability density function (PDF):
-#' m(x) = [1 - F(x)] / f(x)
+#' m(x) = \\[1 - F(x)\\] / f(x)
 #'
 #' @author John Gavin <john.b.gavin@gmail.com>
 

--- a/man/mills_ratio_normal.Rd
+++ b/man/mills_ratio_normal.Rd
@@ -22,7 +22,7 @@ Numeric vector of Mills ratios
 Functions to compute Mills ratios for different probability distributions.
 The Mills ratio m(x) is defined as the ratio of the complementary cumulative
 distribution function (CCDF) to the probability density function (PDF):
-m(x) = \link{1 - F(x)} / f(x)
+m(x) = \[1 - F(x)\] / f(x)
 }
 \examples{
 # Standard normal Mills ratio at x = 2


### PR DESCRIPTION
## Summary
This PR fixes the CI failures identified in #1.

## Changes
- Fixed Rd cross-reference warning by escaping brackets in roxygen2 comments  
- Added missing entries to .Rbuildignore (_targets.R, default-ci.nix, README.qmd, result)
- Regenerated documentation with devtools::document()
- Added tracking script in R/dev/issues/fix_issue_1.R (per 9-step workflow)

## Testing
Local devtools::check() passes with:
- 0 errors
- 0 warnings  
- 2 notes (non-blocking)

## CI Status
Monitoring Nix-based workflows only (per our CI strategy).

Fixes #1